### PR TITLE
allowing to choose between Detail and Short subscription link

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -36,7 +36,7 @@ used to pass the data in and out of the APIs are described below.
 		
 		def initialize(store_id, api_username, api_password)
 		
-		def create_subscription(product_ref, referrer)
+		def create_subscription(product_ref, referrer, order_type=:detail)
 		
 		def get_subscription(subscription_ref)
 		

--- a/lib/FastSpring.rb
+++ b/lib/FastSpring.rb
@@ -17,8 +17,9 @@ class FastSpring
     @store_id = store_id
   end
   
-  def create_subscription(product_ref, referrer)
-    url = "http://sites.fastspring.com/" <<  @store_id << "/product/" << product_ref << "?referrer=" << referrer;
+  def create_subscription(product_ref, referrer, order_type=:detail)
+    order_types = {:detail => "product", :short => "instant"}
+    url = "https://sites.fastspring.com/#{@store_id}/#{order_types[order_type]}/#{product_ref}?referrer=#{referrer}"
     url = add_test_mode(url)
   end
   


### PR DESCRIPTION
A small change that allows to select between a `Detail` order page or `Short` one.

Also changed the URL to use `https` instead of `http`
