### PR TITLE
adding a 'checkout' flow

### DIFF
--- a/lib/FastSpring.rb
+++ b/lib/FastSpring.rb
@@ -18,8 +18,8 @@ class FastSpring
   end
   
   def create_subscription(product_ref, referrer, order_type=:detail)
-    protocols = {:detail => "http", :short => "https"}
-    order_types = {:detail => "product", :short => "instant"}
+    protocols = {:detail => "http", :short => "https", :checkout => "https"}
+    order_types = {:detail => "product", :short => "instant", :checkout => "checkout"}
     url = "#{protocols[order_type]}://sites.fastspring.com/#{@store_id}/#{order_types[order_type]}/#{product_ref}?referrer=#{referrer}"
     url = add_test_mode(url)
   end


### PR DESCRIPTION
Would be nice to add this to the possible `create_subscription` options, so a user can go straight to checkout and also see a coupon field.
