### PR TITLE
Include the response error in the FsprgException

### DIFF
--- a/lib/FastSpring.rb
+++ b/lib/FastSpring.rb
@@ -61,7 +61,7 @@ class FastSpring
     if response.code == 200
       sub = parse_subscription(response.parsed_response.fetch('subscription'))
     else
-      exception = FsprgException.new(response.code, response.parse_response)
+      exception = FsprgException.new(response.code, response.parsed_response)
       raise exception, "An error occurred calling the FastSpring subscription service", caller
     end
     

--- a/lib/FastSpring.rb
+++ b/lib/FastSpring.rb
@@ -36,7 +36,6 @@ class FastSpring
   end
   
   def update_subscription(subscription_update)
-    byebug
     url = subscription_url(subscription_update.reference)
     
     options = { :headers => { 'Content-Type' => 'application/xml' }, :body => subscription_update.to_xml, :basic_auth => @auth }

--- a/lib/FastSpring.rb
+++ b/lib/FastSpring.rb
@@ -28,7 +28,7 @@ class FastSpring
     if response.code == 200
       sub = parse_subscription(response.parsed_response.fetch('subscription'))
     else
-      exception = FsprgException.new(response.code, nil)
+      exception = FsprgException.new(response.code, response.parsed_response)
       raise exception, "An error occurred calling the FastSpring subscription service", caller
     end
     
@@ -36,6 +36,7 @@ class FastSpring
   end
   
   def update_subscription(subscription_update)
+    byebug
     url = subscription_url(subscription_update.reference)
     
     options = { :headers => { 'Content-Type' => 'application/xml' }, :body => subscription_update.to_xml, :basic_auth => @auth }
@@ -44,7 +45,7 @@ class FastSpring
     if response.code == 200
       sub = parse_subscription(response.parsed_response.fetch('subscription'))
     else
-      exception = FsprgException.new(response.code, nil)
+      exception = FsprgException.new(response.code, response.parsed_response)
       raise exception, "An error occurred calling the FastSpring subscription service", caller
     end
     
@@ -60,7 +61,7 @@ class FastSpring
     if response.code == 200
       sub = parse_subscription(response.parsed_response.fetch('subscription'))
     else
-      exception = FsprgException.new(response.code, nil)
+      exception = FsprgException.new(response.code, response.parse_response)
       raise exception, "An error occurred calling the FastSpring subscription service", caller
     end
     


### PR DESCRIPTION
When updating an error could occur. Include the error as error_code in FsprgException to make the error accessible to the calling class.